### PR TITLE
Fix typos across codebase; correct 'Omniscient' UI label

### DIFF
--- a/ai_animation/src/config.ts
+++ b/ai_animation/src/config.ts
@@ -28,7 +28,7 @@ export const config = {
   // Webhook URL for phase change notifications (optional)
   webhookUrl: import.meta.env.VITE_WEBHOOK_URL || '',
   get isTestingMode(): boolean {
-    // have playwrite inject a marker saying that it's testing to brower
+    // have Playwright inject a marker saying that it's testing to browser
     return import.meta.env.VITE_TESTING_MODE === 'True' || import.meta.env.VITE_TESTING_MODE === 'true' || window.isUnderTest;
   },
   _isTestingMode: false,

--- a/ai_animation/src/gameState.ts
+++ b/ai_animation/src/gameState.ts
@@ -296,7 +296,7 @@ class GameState {
   }
 
   /*
-   * Loads the next game in the order, reseting the board and gameState
+   * Loads the next game in the order, resetting the board and gameState
    */
   loadNextGame = (setPlayback: boolean = false) => {
     // Ensure any open overlays are cleaned up before loading next game

--- a/ai_animation/src/main.ts
+++ b/ai_animation/src/main.ts
@@ -29,7 +29,7 @@ function initScene() {
 
 
   // Initialize standings board
-  // TODO: Re-add standinds board when it has an actual use, and not stale data
+  // TODO: Re-add standings board when it has an actual use, and not stale data
   //
   //initStandingsBoard();
 
@@ -163,7 +163,7 @@ function animate() {
   if (hasPanicked) return; // Stop the loop if we've panicked
   
   try {
-    // All things that aren't ThreeJS items happen in the eventQueue. The queue if filled with the first phase before the animate is kicked off, then all subsequent events are updated when other events finish. F
+    // All things that aren't ThreeJS items happen in the eventQueue. The queue is filled with the first phase before the animate is kicked off, then all subsequent events are updated when other events finish.
     // For instance, when the messages finish playing, they should kick off the check to see if we should advance turns.
     gameState.eventQueue.update();
   } catch (error) {
@@ -176,7 +176,7 @@ function animate() {
 
   if (gameState.isPlaying) {
     // Update the camera angle
-    // FIXME: This has to call the update functino twice inorder to avoid a bug in Tween.js, see here  https://github.com/tweenjs/tween.js/issues/677
+    // FIXME: This has to call the update function twice in order to avoid a bug in Tween.js, see here  https://github.com/tweenjs/tween.js/issues/677
     gameState.cameraPanAnim.update();
     gameState.cameraPanAnim.update();
 

--- a/ai_animation/src/phase.ts
+++ b/ai_animation/src/phase.ts
@@ -150,7 +150,7 @@ export function scheduleSummarySpeech() {
   }, `speech-delay-${Date.now()}`);
 }
 
-/** Handels all the end-of-phase items before calling _setPhase().
+/** Handles all the end-of-phase items before calling _setPhase().
  *
  */
 export function nextPhase() {

--- a/ai_animation/src/types/events.ts
+++ b/ai_animation/src/types/events.ts
@@ -79,7 +79,7 @@ export class EventQueue {
 
           event.callback();
         } catch (err) {
-          // TODO: Need some system here to catch and report errors, but we mark them as resolved now so that we don't call an erroring fucntion repeatedly.
+          // TODO: Need some system here to catch and report errors, but we mark them as resolved now so that we don't call an erroring function repeatedly.
           this.events.slice(this.events.indexOf(event), 1)
           if (err instanceof Error) {
             event.error = err

--- a/diplomacy/README_MAPS.txt
+++ b/diplomacy/README_MAPS.txt
@@ -73,7 +73,7 @@ the equals-sign in each placename line).
 
 Specifying Army and Fleet Restrictions
 ===========================
-This directive is case-sensitive. Army and fleet restrictions are specifyied by use of upper- and
+This directive is case-sensitive. Army and fleet restrictions are specified by use of upper- and
 lower-case as described below. Everything must be in upper-case except the following:
 
 The abbreviation for any COAST location that a fleet cannot occupy must be listed entirely in

--- a/diplomacy/communication/requests.py
+++ b/diplomacy/communication/requests.py
@@ -50,7 +50,7 @@
     - the Python client returned values (important)
 
     All requests classes inherit from :class:`._AbstractRequest` which require parameters
-    ``name`` (from parant class :class:`.NetworkData`), ``request_id`` and ``re_sent``.
+    ``name`` (from parent class :class:`.NetworkData`), ``request_id`` and ``re_sent``.
     These parameters are automatically filled by the client.
 
     From parent class :class:`._AbstractRequest`, we get 3 types of requests:
@@ -61,7 +61,7 @@
       connection request :class:`.SignIn`, and is then used to create a :class:`.Channel` object.
       Channel object will be responsible for sending all other channel requests, automatically
       filling token field for these requests.
-    - game requests, intherited from :class:`._AbstractGameRequest`, which itself inherit from
+    - game requests, inherited from :class:`._AbstractGameRequest`, which itself inherit from
       :class:`._AbstractChannelRequest`, and requires additional parameters ``game_id``, ``game_role``
       and ``phase`` (game short phase name). Game ID, role and phase are retrieved for a specific game
       by the client when he joined a game through one of featured :class:`.Channel` methods which return
@@ -423,7 +423,7 @@ class JoinPowers(_AbstractChannelRequest):
         :param registration_password: password to join the game
         :type game_id: str
         :type power_names: list, optional
-        :type registration_password: str, optionl
+        :type registration_password: str, optional
         :return: None. If request succeeds, then the user is registered as player for all
             given power names. The user can then simply join game to one of these powers (by sending
             a :class:`.JoinGame` request), and he will be able to manage all the powers through

--- a/diplomacy/daide/notification_managers.py
+++ b/diplomacy/daide/notification_managers.py
@@ -132,7 +132,7 @@ def on_processed_notification(server, notification, connection_handler, game):
     return notifs
 
 def on_status_update_notification(server, notification, connection_handler, game):
-    """ Build the list of notificaitons for a status update event
+    """ Build the list of notifications for a status update event
 
         :param server: server which receives the request
         :param notification: internal notification
@@ -162,7 +162,7 @@ def on_status_update_notification(server, notification, connection_handler, game
     return notifs
 
 def on_message_received_notification(server, notification, connection_handler, game):
-    """ Build the list of notificaitons for a message received event
+    """ Build the list of notifications for a message received event
 
         :param server: server which receives the request
         :param notification: internal notification

--- a/diplomacy/daide/notifications.py
+++ b/diplomacy/daide/notifications.py
@@ -75,7 +75,7 @@ class HelloNotification(DaideNotification):
             MTL seconds     # Movement time limit
             RTL seconds     # Retreat time limit
             BTL seconds     # Build time limit
-            DSD             # Disables the time limit when a client disconects
+            DSD             # Disables the time limit when a client disconnects
             AOA             # Any orders accepted
 
         LVL 10:

--- a/diplomacy/daide/request_managers.py
+++ b/diplomacy/daide/request_managers.py
@@ -81,7 +81,7 @@ def on_observer_request(server, request, connection_handler, game):
         :return: the list of responses
     """
     del server, connection_handler, game            # Unused args
-    return [responses.REJ(bytes(request))]          # No DAIDE observeres allowed
+    return [responses.REJ(bytes(request))]          # No DAIDE observers allowed
 
 @gen.coroutine
 def on_i_am_request(server, request, connection_handler, game):

--- a/diplomacy/daide/responses.py
+++ b/diplomacy/daide/responses.py
@@ -371,7 +371,7 @@ class HelloResponse(DaideResponse):
             MTL seconds     # Movement time limit
             RTL seconds     # Retreat time limit
             BTL seconds     # Build time limit
-            DSD             # Disables the time limit when a client disconects
+            DSD             # Disables the time limit when a client disconnects
             AOA             # Any orders accepted
 
         LVL 10:
@@ -700,7 +700,7 @@ class AcceptResponse(DaideResponse):
 
             YES (DRW (power power ...))                         # Accepts a partial draw
             YES (NOT (DRW (power power ...)))                   # Accepts to cancel a partial draw request
-                                                                  (? not mentinned in the DAIDE doc)
+                                                                  (? not mentioned in the DAIDE doc)
             YES (SND (power power ...) (press_message))         # Accepts a press message
             YES (SND (turn) (power power ...) (press_message))  # Accepts a press message
     """
@@ -722,8 +722,8 @@ class RejectResponse(DaideResponse):
             REJ (HLO)                                           # Rejects to send the HLO message
             REJ (HST (turn))                                    # Rejects to send a copy of a previous
                                                                   ORD, SCO and NOW messages
-            REJ (SUB (order) (order))                           # Rejects a submition of orders
-            REJ (SUB (turn) (order) (order))                    # Rejects a submition of orders
+            REJ (SUB (order) (order))                           # Rejects a submission of orders
+            REJ (SUB (turn) (order) (order))                    # Rejects a submission of orders
             REJ (NOT (SUB (order)))                             # Rejects a cancellation of a submitted order
             REJ (MIS)                                           # Rejects to send a copy of the current MIS message
             REJ (GOF)                                           # Rejects to wait until the deadline before processing

--- a/diplomacy/daide/tests/test_daide_game.py
+++ b/diplomacy/daide/tests/test_daide_game.py
@@ -86,7 +86,7 @@ class ClientCommsSimulator:
 
     @property
     def is_game_joined(self):
-        """ Returns if the client has joinded the game """
+        """ Returns if the client has joined the game """
         return self._is_game_joined
 
     def set_comms(self, comms):
@@ -103,7 +103,7 @@ class ClientCommsSimulator:
         while comm_idx < len(self._comms):
             comm = self._comms[comm_idx]
 
-            # Find the request being right after a synchonization point (TME notification)
+            # Find the request being right after a synchronization point (TME notification)
             if not comm.request:
                 comm_idx += 1
                 continue
@@ -299,7 +299,7 @@ class ClientsCommsSimulator:
 
     @gen.coroutine
     def retrieve_game_port(self, host, port):
-        """ Retreive and store the game's port
+        """ Retrieve and store the game's port
 
             :param host: the host
             :param port: the port

--- a/diplomacy/engine/game.py
+++ b/diplomacy/engine/game.py
@@ -2125,7 +2125,7 @@ class Game(Jsonable):
         if not homes:
             return 99999
 
-        # Modified Djikstra
+        # Modified Dijkstra
         to_check = PriorityDict()
         to_check[start] = 0
         while to_check:
@@ -3096,7 +3096,7 @@ class Game(Jsonable):
     def _transfer_center(self, from_power, to_power, center):
         """ Transfers a supply center from a power to another
 
-            :param from_power: The power instance from whom the supply center is transfered
+            :param from_power: The power instance from whom the supply center is transferred
             :param to_power: The power instance to whom the supply center is transferred
             :param center: The supply center location (e.g. 'PAR')
             :return: Nothing

--- a/diplomacy/maps/svg/svg.dtd
+++ b/diplomacy/maps/svg/svg.dtd
@@ -129,7 +129,7 @@
     <!-- 'stroke-dasharray' property/attribute value (e.g., 'none', list of <number>s) -->
 
 <!ENTITY % StrokeDashOffsetValue "CDATA">
-    <!-- 'stroke-dashoffset' property/attribute value (e.g., 'none', <legnth>) -->
+    <!-- 'stroke-dashoffset' property/attribute value (e.g., 'none', <length>) -->
 
 <!ENTITY % StrokeMiterLimitValue "CDATA">
     <!-- 'stroke-miterlimit' property/attribute value (e.g., <number>) -->

--- a/diplomacy/utils/export.py
+++ b/diplomacy/utils/export.py
@@ -94,7 +94,7 @@ def from_saved_game_format(saved_game):
     return game
 
 def load_saved_games_from_disk(input_path, on_error='raise'):
-    """ Rebuids multiple :class:`diplomacy.engine.game.Game` from each line in a .jsonl file
+    """ Rebuilds multiple :class:`diplomacy.engine.game.Game` from each line in a .jsonl file
 
         :param input_path: The path to the input file. Expected content is one saved_game json per line.
         :param on_error: Optional. What to do if a game conversion fails. Either 'raise', 'warn', 'ignore'

--- a/diplomacy/web/src/gui/pages/content_game.jsx
+++ b/diplomacy/web/src/gui/pages/content_game.jsx
@@ -76,7 +76,7 @@ const TABLE_POWER_VIEW = {
 };
 
 const PRETTY_ROLES = {
-    [STRINGS.OMNISCIENT_TYPE]: 'Omnicient',
+    [STRINGS.OMNISCIENT_TYPE]: 'Omniscient',
     [STRINGS.OBSERVER_TYPE]: 'Observer'
 };
 

--- a/diplomacy/web/svg_to_react.py
+++ b/diplomacy/web/svg_to_react.py
@@ -385,7 +385,7 @@ def to_json_string(dictionary):
 
 
 def minify(code):
-    """ Minifyies a Javascript / CSS file """
+    """ Minifies a Javascript / CSS file """
     code = LINES_REGEX.sub(' ', code)
     code = SPACES_REGEX.sub(' ', code)
     code = STRING_REGEX.sub(' ', code)
@@ -438,7 +438,7 @@ export const Colors = %(colors)s;
        'symbol_sizes': to_json_string(data.get_symbol_sizes()),
        'colors': to_json_string(data.get_colors())})
 
-    # Map javacript
+    # Map javascript
     map_js_code = ("""
 import React from 'react';
 import PropTypes from 'prop-types';
@@ -770,7 +770,7 @@ export class %(classname)s extends React.Component {
                         throw new Error('Unknown neighbor province ' + neighbor);
                     const neighborID = neighborProvince.getID(classes);
                     if (!neighborID)
-                        throw new Error(`Unknown neoghbor path (${neighborID}) for province (${neighbor}).`);
+                        throw new Error(`Unknown neighbor path (${neighborID}) for province (${neighbor}).`);
                     classes[neighborID] = neighborProvince.isWater() ? 'provinceBlue' : 'provinceGreen';
                 }
             }


### PR DESCRIPTION
Standardize spelling in comments, docstrings, and error strings. No functional changes; only text fixes and clearer messages. Notable: Dijkstra, transferred, disconnects, submission, synchronize. Also clean up README_MAPS and SVG DTD comment typos.